### PR TITLE
STYLE: Upgrade python syntax to 3.6 and newer

### DIFF
--- a/ABLTemporalBoneSegmentationModule/ABLTemporalBoneSegmentationModule.py
+++ b/ABLTemporalBoneSegmentationModule/ABLTemporalBoneSegmentationModule.py
@@ -635,7 +635,7 @@ class ABLTemporalBoneSegmentationModuleWidget(ScriptedLoadableModuleWidget):
             output = function()
             if set_moving_volume: self.movingSelector.setCurrentNode(output)
         except Exception as e:
-            self.update_rigid_progress("Error: {0}".format(e))
+            self.update_rigid_progress(f"Error: {e}")
             import traceback
             traceback.print_exc()
         finally:
@@ -679,7 +679,7 @@ class ABLTemporalBoneSegmentationModuleWidget(ScriptedLoadableModuleWidget):
         progress = ABLTemporalBoneSegmentationModuleLogic.process_rigid_progress(text)
         self.rigidStatus.text = 'Status: ' + ((text[:60] + '..') if len(text) > 60 else text)
         if progress is not None: self.rigidProgress.value = progress
-        if progress is 100:
+        if progress == 100:
             self.rigidProgress.visible = False
             self.rigidCancelButton.visible = False
             p = qt.QPalette()
@@ -696,7 +696,7 @@ class ABLTemporalBoneSegmentationModuleWidget(ScriptedLoadableModuleWidget):
         self.update_sections_enabled(validity)
         if not validity and self.inputSelector.currentNode() is None: return
         # check for auto side selection
-        s = re.search("\d+\w_", self.inputSelector.currentNode().GetName())
+        s = re.search(r"\d+\w_", self.inputSelector.currentNode().GetName())
         if s is not None:
             s = s.group(0)[-2]
             if s == 'R': self.click_right_bone(force=True)
@@ -900,7 +900,7 @@ class ABLTemporalBoneSegmentationModuleWidget(ScriptedLoadableModuleWidget):
 
         ## First load the model
         try:
-            with open(os.path.join(os.path.dirname(__file__), "Resources", "Models", "ABLTempSeg.json"), 'r') as f:
+            with open(os.path.join(os.path.dirname(__file__), "Resources", "Models", "ABLTempSeg.json")) as f:
                 model = json.load(f)
         except Exception as e:
             traceback.print_exc()
@@ -1125,7 +1125,7 @@ class ABLTemporalBoneSegmentationModuleWidget(ScriptedLoadableModuleWidget):
             return
 
         l = slicer.app.layoutManager()
-        if l.threeDViewCount == 0 or not any((l.threeDWidget(i).visible for i in range(l.threeDViewCount))):
+        if l.threeDViewCount == 0 or not any(l.threeDWidget(i).visible for i in range(l.threeDViewCount)):
             ## No visible 3D views, switch layouts
             self.switch_to_3dview()
 

--- a/IntraSampleRegistration/IntraSampleRegistration.py
+++ b/IntraSampleRegistration/IntraSampleRegistration.py
@@ -315,7 +315,7 @@ class IntraSampleRegistrationWidget(ScriptedLoadableModuleWidget):
             executed = len([p for p in self.volumePairs if p.status in [PairStatus.EXECUTING, PairStatus.COMPLETE]])
             total = len([p for p in self.volumePairs if p.status == PairStatus.PENDING]) + executed
             self.progressBar.setFormat(str(progress) + '% (' + str(executed) + ' of ' + str(total) + ')')
-            if progress is 100:
+            if progress == 100:
                 self.state = IntraSampleRegistrationState.FINISHED
         if current_registration_step is not None and self.state is not IntraSampleRegistrationState.FINISHED:
             registration = None


### PR DESCRIPTION
Some syntax upgrading is necessary for Slicer-ABLTemporalBoneSegmentation as I noticed in https://slicer.cdash.org/viewBuildError.php?buildid=2625902 that there were syntax warnings. These warnings are present because Slicer recently upgrade from Python 3.6.7 to Python 3.9.10 in https://github.com/Slicer/Slicer/commit/34e48e8aef5dad19ec8a955d6f48a1940846e3f3.

The syntax warning in question started as of Python 3.8.
https://docs.python.org/3.8/whatsnew/3.8.html#changes-in-python-behavior

> The compiler now produces a [SyntaxWarning](https://docs.python.org/3.8/library/exceptions.html#SyntaxWarning) when identity checks (is and is not) are used with certain types of literals (e.g. strings, numbers). These can often work by accident in CPython, but are not guaranteed by the language spec. The warning advises users to use equality tests (== and !=) instead. (Contributed by Serhiy Storchaka in [bpo-34850](https://bugs.python.org/issue34850).)

This PR uses [`pyupgrade`](https://github.com/asottile/pyupgrade) to automatically upgrade python syntax to newer versions. The script listed below was run for Python 3.6+ syntax with changes committed, followed by Python 3.7+, then Python 3.8+ and finally Python 3.9+.  There were no changes made when specifying Python 3.7+, 3.8+ or 3.9+ which is why there are no commits for those iterations.

## Using pyupgrade

- Install: `PythonSlicer -m pip install pyupgrade`
- Running:
  - On 1 file: `PythonSlicer -m pyupgrade --py36-plus MyPythonFile.py`
  - On multiple files: Here is my pyupgrade-script.py written to automate running pyupgrade across all python files in the Slicer repo. It was run by `PythonSlicer pyupgrade-script.py`.
```python
# pyupgrade-script.py
import os
import subprocess

search_directory = "C:/Users/JamesButler/Documents/GitHub/Slicer-ABLTemporalBoneSegmentation"
for root, _, files in os.walk(search_directory):
    for file_item in files:
        file_path = os.path.join(root, file_item)
        if os.path.isfile(file_path) and file_path.endswith(".py"):
            subprocess.call(["PythonSlicer", "-m", "pyupgrade", "--py36-plus", file_path])
```